### PR TITLE
Fix for failing github actions workflow 

### DIFF
--- a/.github/workflows/nf-test-gpu.yml
+++ b/.github/workflows/nf-test-gpu.yml
@@ -92,9 +92,6 @@ jobs:
         run: |
           nvidia-smi -L
 
-      - name: Enable Nextflow debug logging
-        run: echo "NXF_DEBUG=2" >> $GITHUB_ENV
-
       - name: Run nf-test Action
         uses: ./.github/actions/nf-test
         with:

--- a/.github/workflows/nf-test.yml
+++ b/.github/workflows/nf-test.yml
@@ -51,7 +51,6 @@ jobs:
           NFT_VER: ${{ env.NFT_VER }}
         with:
           max_shards: 7
-          tags: "stub"
 
       - name: debug
         run: |
@@ -65,11 +64,12 @@ jobs:
     runs-on: # use self-hosted runners
       - runs-on=${{ github.run_id }}-nf-test
       - runner=4cpu-linux-x64
+      - volume=80gb
     strategy:
       fail-fast: false
       matrix:
         shard: ${{ fromJson(needs.nf-test-changes.outputs.shard) }}
-        profile: [conda, docker, singularity]
+        profile: [docker, singularity]
         isMain:
           - ${{ github.base_ref == 'master' || github.base_ref == 'main' }}
         # Exclude conda and singularity on dev


### PR DESCRIPTION
<!--
# nf-core/lsmquant pull request

Many thanks for contributing to nf-core/lsmquant!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

Remember that PRs should be made against the dev branch, unless you're preparing a pipeline release.

Learn more about contributing: [CONTRIBUTING.md](https://github.com/nf-core/lsmquant/tree/master/.github/CONTRIBUTING.md)
-->

## PR checklist

- [ ] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/nf-core/lsmquant/tree/master/.github/CONTRIBUTING.md)
- [ ] If necessary, also make a PR on the nf-core/lsmquant _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [ ] Make sure your code lints (`nf-core pipelines lint`).
- [ ] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [ ] Check for unexpected warnings in debug mode (`nextflow run . -profile debug,test,docker --outdir <OUTDIR>`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [ ] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).

nf-test:
- Fails while creating sif image : no space left: adding -volume=80gb
- deleting stub tag: artifact from the time where i had no test data available
- deleting conda since i dont use conda in the pipeline
nf-test-gpu:
- deleting debugg statement in the workflow 
