### PR TITLE
fix variable naming

### DIFF
--- a/workflows/lsmquant.nf
+++ b/workflows/lsmquant.nf
@@ -134,7 +134,7 @@ workflow LSMQUANT {
 
     stitched_data = ch_samplesheet
             .join (stitched_output)
-            .map { meta, input_img, parameter_file, stitched_data ->
+            .map { meta, img_directory, parameter_file, stitched_data ->
                 [meta, stitched_data, parameter_file]
             }
 

--- a/workflows/lsmquant.nf
+++ b/workflows/lsmquant.nf
@@ -134,7 +134,7 @@ workflow LSMQUANT {
 
     stitched_data = ch_samplesheet
             .join (stitched_output)
-            .map { meta, img_dir, parameter_file, stitched_data ->
+            .map { meta, input_img, parameter_file, stitched_data ->
                 [meta, stitched_data, parameter_file]
             }
 


### PR DESCRIPTION
<!--
# nf-core/lsmquant pull request

Many thanks for contributing to nf-core/lsmquant!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

Remember that PRs should be made against the dev branch, unless you're preparing a pipeline release.

Learn more about contributing: [CONTRIBUTING.md](https://github.com/nf-core/lsmquant/tree/master/.github/CONTRIBUTING.md)
-->

## PR checklist

- [ ] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/nf-core/lsmquant/tree/master/.github/CONTRIBUTING.md)
- [ ] If necessary, also make a PR on the nf-core/lsmquant _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [ ] Make sure your code lints (`nf-core pipelines lint`).
- [ ] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [ ] Check for unexpected warnings in debug mode (`nextflow run . -profile debug,test,docker --outdir <OUTDIR>`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [ ] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
fix for : 

```
ERROR    Command 'nextflow inspect -format json -profile                        
         singularity,test,test_full                                             
         /home/runner/work/lsmquant/lsmquant/lsmquant/dev/main.nf' returned     
         non-zero error code '1':                                               
         >                                                                      
         Error workflows/lsmquant.nf:137:26: `img_dir` is already declared      
         │ 137 |             .map { meta, img_dir, parameter_file, stitched_data
         ->                                                                     
         ╰     |                          ^^^^^^^                               
                                                                                
                                                                                
         ERROR ~ Script compilation failed   
```                                   
in : #61 