### PR TITLE
Set matlab cache directory within the process

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - [PR#57](https://github.com/nf-core/lsmquant/pull/57) - Fix input declaration of the model file for the module: `numorph3dunet` to be reused for all inputs.
 - remove conda batch from readme, the pipeline does not support conda.
+- set matlab cache directory in numorph_stitch to fix concurrency issues when running multiple samples.
 
 ## v1.0.0 - Excited Squid
 

--- a/modules/local/numorphstitch/main.nf
+++ b/modules/local/numorphstitch/main.nf
@@ -23,6 +23,8 @@ process NUMORPHSTITCH {
     def NM_var = NM_variable ? NM_variable : ''
     def variables_input = variables ? variables : ''
     """
+    export MCR_CACHE_ROOT=\${PWD}/.mcrCache
+
     # create output directories needed by the tool
     mkdir -p ./results/stitched/
 


### PR DESCRIPTION
<!--
# nf-core/lsmquant pull request

Many thanks for contributing to nf-core/lsmquant!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

Remember that PRs should be made against the dev branch, unless you're preparing a pipeline release.

Learn more about contributing: [CONTRIBUTING.md](https://github.com/nf-core/lsmquant/tree/master/.github/CONTRIBUTING.md)
-->

## PR checklist

- [ ] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/nf-core/lsmquant/tree/master/.github/CONTRIBUTING.md)
- [ ] If necessary, also make a PR on the nf-core/lsmquant _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [ ] Make sure your code lints (`nf-core pipelines lint`).
- [ ] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [ ] Check for unexpected warnings in debug mode (`nextflow run . -profile debug,test,docker --outdir <OUTDIR>`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [ ] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).

Setting the MATLAB cache dir within the process numorph_stitch fixes cache concurrency issues when processing multiple samples