### PR TITLE
fix Stitching

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [PR#62](https://github.com/nf-core/lsmquant/pull/62) - Template update
 - zenodo DOI to cite all versions
 - new metromap (smaller nf-core logo, fix typo)
+- [PR#69](https://github.com/nf-core/lsmquant/pull/69) - Fix to prevent stitching from starting twice when “NM_variables” is specified
 
 ## 1.0.1 - Excited Squid Patch
 

--- a/modules/local/numorphstitch/main.nf
+++ b/modules/local/numorphstitch/main.nf
@@ -42,9 +42,9 @@ process NUMORPHSTITCH {
     if [ -n "${NM_var}" ]; then
         NM_variables=\$(readlink -f ${NM_var})
         numorph_preprocessing 'input_dir' \$img_dir 'output_dir' \$results_dir 'parameter_file' \$parameter_file 'sample_name' ${meta.id} 'stage' 'stitch' 'NM_variables' \$NM_variables
+    else
+        numorph_preprocessing 'input_dir' \$img_dir 'output_dir' \$results_dir 'parameter_file' \$parameter_file 'sample_name' ${meta.id} 'stage' 'stitch'
     fi
-
-    numorph_preprocessing 'input_dir' \$img_dir 'output_dir' \$results_dir 'parameter_file' \$parameter_file 'sample_name' ${meta.id} 'stage' 'stitch'
 
     """
 


### PR DESCRIPTION
<!--
# nf-core/lsmquant pull request

Many thanks for contributing to nf-core/lsmquant!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

Remember that PRs should be made against the dev branch, unless you're preparing a pipeline release.

Learn more about contributing: [CONTRIBUTING.md](https://github.com/nf-core/lsmquant/tree/master/.github/CONTRIBUTING.md)
-->

## PR checklist

- [ ] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/nf-core/lsmquant/tree/master/.github/CONTRIBUTING.md)
- [ ] If necessary, also make a PR on the nf-core/lsmquant _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [ ] Make sure your code lints (`nf-core pipelines lint`).
- [ ] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [ ] Check for unexpected warnings in debug mode (`nextflow run . -profile debug,test,docker --outdir <OUTDIR>`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [ ] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).

Fix the if-else statement to prevent stitching starting 2x if NM_variables is provided!